### PR TITLE
Updated to Enqueue 0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,17 +26,17 @@
     ],
     "require": {
         "php": "^7.1",
-        "enqueue/enqueue": "^0.7",
+        "enqueue/enqueue": "^0.7|^0.8",
         "prooph/common" : "^4.1",
         "prooph/service-bus" : "^6.0",
         "queue-interop/queue-interop": "^0.6.1"
     },
     "require-dev": {
 	    "react/promise": "^2.4.1",
-        "enqueue/simple-client": "^0.7",
+        "enqueue/simple-client": "^0.7|^0.8",
         "symfony/filesystem": "^2.1|^3",
-        "enqueue/fs": "^0.7",
-        "enqueue/null": "^0.7",
+        "enqueue/fs": "^0.7|^0.8",
+        "enqueue/null": "^0.7|^0.8",
         "psr/container": "^1.0",
         "sandrokeil/interop-config": "^2.0.1",
         "phpspec/prophecy": "^1.7",


### PR DESCRIPTION
I've only added an alternate version to allow 0.8 and ran the tests, which all complete successfully. This seems safer than having a constraint of `~0.7` since they can still introduce breaking changes before their 1.0 release. 