### PR TITLE
Updated to allow PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,14 @@ matrix:
     - php: 7.1
       env:
         - DEPENDENCIES="--prefer-lowest --prefer-stable"
+    - php: 7.2
+      env:
+        - DEPENDENCIES=""
+        - EXECUTE_CS_CHECK=true
+        - TEST_COVERAGE=true
+    - php: 7.2
+      env:
+        - DEPENDENCIES="--prefer-lowest --prefer-stable"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
     - php: 7.2
       env:
         - DEPENDENCIES=""
-        - EXECUTE_CS_CHECK=true
         - TEST_COVERAGE=true
     - php: 7.2
       env:

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "psr/container": "^1.0",
         "sandrokeil/interop-config": "^2.0.1",
         "phpspec/prophecy": "^1.7",
-        "prooph/php-cs-fixer-config": "^0.1.1",
+        "prooph/php-cs-fixer-config": "^0.2",
         "phpunit/phpunit": "^6.0",
         "malukenho/docheader": "^0.1.4"
     },


### PR DESCRIPTION
Updates the version of `prooph/php-cs-fixer-config` to allow installation against PHP 7.2.